### PR TITLE
Fixed compatibility issues with Android 2.2

### DIFF
--- a/src/main/java/com/firebase/tubesock/WebSocket.java
+++ b/src/main/java/com/firebase/tubesock/WebSocket.java
@@ -178,9 +178,10 @@ public class WebSocket extends Thread {
     /**
      * Send a TEXT message over the socket
      * @param data The text payload to be sent
+     * @throws UnsupportedEncodingException cannot really be thrown in practice
      */
-    public synchronized void send(String data) {
-        send(OPCODE_TEXT, data.getBytes(UTF8));
+    public synchronized void send(String data) throws UnsupportedEncodingException {
+        send(OPCODE_TEXT, data.getBytes(UTF8.name()));
     }
 
     /**


### PR DESCRIPTION
The constructor `String(byte[] data, Charset charset)` has only been introduced in Android 2.3 while the constructor `String(byte[] data, String charsetName)` is available on _all_ Android versions.

Source: http://developer.android.com/reference/java/lang/String.html

The README says `[...] Android, tested on version 2.2 and forward [...]` but the library will crash on Android 2.2 without this patch.
