### PR TITLE
Do not use default locale but specify one to avoid bugs

### DIFF
--- a/src/main/java/com/firebase/tubesock/WebSocketHandshake.java
+++ b/src/main/java/com/firebase/tubesock/WebSocketHandshake.java
@@ -1,5 +1,6 @@
 package com.firebase.tubesock;
 
+import java.util.Locale;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -92,9 +93,9 @@ class WebSocketHandshake {
     }
 
     public void verifyServerHandshakeHeaders(HashMap<String, String> headers) {
-        if (!headers.get("Upgrade").toLowerCase().equals("websocket")) {
+        if (!headers.get("Upgrade").toLowerCase(Locale.US).equals("websocket")) {
             throw new WebSocketException("connection failed: missing header field in server handshake: Upgrade");
-        } else if (!headers.get("Connection").toLowerCase().equals("upgrade")) {
+        } else if (!headers.get("Connection").toLowerCase(Locale.US).equals("upgrade")) {
             throw new WebSocketException("connection failed: missing header field in server handshake: Connection");
         }
     }


### PR DESCRIPTION
> Be wary of the default locale
>
>Note that there are many convenience methods that automatically use the default locale, but using them may lead to subtle bugs.
>
>The default locale is appropriate for tasks that involve presenting data to the user. In this case, you want to use the user's date/time formats, number formats, rules for conversion to lowercase, and so on. In this case, it's safe to use the convenience methods.
>
>The default locale is not appropriate for machine-readable output. The best choice there is usually Locale.US – this locale is guaranteed to be available on all devices, and the fact that it has no surprising special cases and is frequently used (especially for computer-computer communication) means that it tends to be the most efficient choice too.
>
>A common mistake is to implicitly use the default locale when producing output meant to be machine-readable. This tends to work on the developer's test devices (especially because so many developers use en_US), but fails when run on a device whose user is in a more complex locale. 

Source: http://developer.android.com/reference/java/util/Locale.html