### PR TITLE
On receive errors, we should not leak sockets.

### DIFF
--- a/src/main/java/com/firebase/tubesock/WebSocket.java
+++ b/src/main/java/com/firebase/tubesock/WebSocket.java
@@ -229,6 +229,7 @@ public class WebSocket extends Thread {
         if (state == State.CONNECTED) {
             close();
         }
+        closeSocket();
     }
 
     /**


### PR DESCRIPTION
We can receive an EOF during reset.  This indicates that the socket has been closed.
But we still attempt to send a handshake close opcode back to the server and wait
for the result to fully clean up the receiving socket.  This leaks resources.

The fix is to close the socket completely on receive errors -- but still send the opcode to
 the server via close() if needed