### PR TITLE
Let HTTP header field names be case-insensitive (RFC 2616, 4.2)

### DIFF
--- a/src/main/java/com/firebase/tubesock/WebSocket.java
+++ b/src/main/java/com/firebase/tubesock/WebSocket.java
@@ -1,7 +1,6 @@
 package com.firebase.tubesock;
 
 import org.apache.http.conn.ssl.StrictHostnameVerifier;
-
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSocket;
@@ -17,6 +16,7 @@ import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -360,7 +360,7 @@ public class WebSocket {
             HashMap<String, String> headers = new HashMap<String, String>();
             for (String line : handshakeLines) {
                 String[] keyValue = line.split(": ", 2);
-                headers.put(keyValue[0], keyValue[1]);
+                headers.put(keyValue[0].toLowerCase(Locale.US), keyValue[1]);
             }
             handshake.verifyServerHandshakeHeaders(headers);
 

--- a/src/main/java/com/firebase/tubesock/WebSocketHandshake.java
+++ b/src/main/java/com/firebase/tubesock/WebSocketHandshake.java
@@ -93,9 +93,9 @@ class WebSocketHandshake {
     }
 
     public void verifyServerHandshakeHeaders(HashMap<String, String> headers) {
-        if (!headers.get("Upgrade").toLowerCase(Locale.US).equals("websocket")) {
+        if (!headers.get("upgrade").toLowerCase(Locale.US).equals("websocket")) {
             throw new WebSocketException("connection failed: missing header field in server handshake: Upgrade");
-        } else if (!headers.get("Connection").toLowerCase(Locale.US).equals("upgrade")) {
+        } else if (!headers.get("connection").toLowerCase(Locale.US).equals("upgrade")) {
             throw new WebSocketException("connection failed: missing header field in server handshake: Connection");
         }
     }


### PR DESCRIPTION
> Please note that according to [RFC2616], all header field names in both HTTP requests and HTTP responses are case-insensitive.
>
> -- RFC 6455, 4.1

and

> Field names are case-insensitive.
>
> -- RFC 2616, 4.2

The field *values* are already handled case-insensitively in `WebSocketHandshake.java` (also as per RFC 6455, 4.1). But the field *keys* still need to be fixed.